### PR TITLE
Support setting limits in the systemd config for the mcrouter service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for mcrouter
 
+## [v3.1.1]
+* Support setting limits in the systemd config for the mcrouter service
+
 ## [v3.1.0]
 * Add support for installing mcrouter from pre-compiled binaries
 * Use attributes for automake package source for centos deps

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,11 @@ default['mcrouter']['cli_opts'] = {
   'stats-root'  => '/var/mcrouter/stats'
 }
 
+default['mcrouter']['limits'] = {
+  # nproc: 81_920,
+  # nfile: 4096
+}
+
 default['mcrouter']['config'] = {
   'pools' => {
     'A' => {

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@evertrue.com'
 license          'Apache-2.0'
 description      'Installs/Configures mcrouter'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '3.1.1'
 chef_version     '>= 12.7' if respond_to?(:chef_version)
 source_url       'https://github.com/evertrue/mcrouter-cookbook'
 issues_url       'https://github.com/evertrue/mcrouter-cookbook/issues'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -24,6 +24,11 @@ systemd_service 'mcrouter' do
   service_working_directory '/usr/local/mcrouter/'
   service_exec_start "/usr/local/mcrouter/bin/mcrouter #{shell_opts(node['mcrouter']['cli_opts'])}"
   service_restart 'on-abort'
+
+  node['mcrouter']['limits'].each do | name, value|
+    send("service_limit_#{name}", value)
+  end
+
   install_wanted_by 'multi-user.target'
   action [:create, :restart]
 end


### PR DESCRIPTION
Version v3.1.1

* Support setting limits in the systemd config for the mcrouter service